### PR TITLE
Fix namespace and logic bugs in Geometry3D and Statistics

### DIFF
--- a/src/code/SMath/Functions1/Identity.cs
+++ b/src/code/SMath/Functions1/Identity.cs
@@ -34,7 +34,7 @@ public class Identity : IMathFunction
     /// <inheritdoc />
     public static (N Min, N Max) NumberDomain<N>()
         where N : IMinMaxValue<N>, IFloatingPointIeee754<N>
-        => (N.MaxValue, N.MaxValue);
+        => (N.MinValue, N.MaxValue);
 
     /// <inheritdoc />
     public static (N Min, N Max) Image<N>()

--- a/src/code/SMath/Geometry3D/Point3.cs
+++ b/src/code/SMath/Geometry3D/Point3.cs
@@ -1,7 +1,7 @@
 ﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 
-namespace SMath.Geometry2D;
+namespace SMath.Geometry3D;
 
 /// <summary>
 /// Point in three dimensions.

--- a/src/code/SMath/Statistics/correlation/PearsonCorrelation.cs
+++ b/src/code/SMath/Statistics/correlation/PearsonCorrelation.cs
@@ -173,7 +173,7 @@ public static class PearsonCorrelation
             if (lag < NInt.Zero)
                 y = iy < 0
                     ? numbers2[0]
-                    : iy < numbers2.Count - iy
+                    : iy < numbers2.Count
                         ? numbers2[iy]
                         : numbers2[numbers2.Count - 1];
             else

--- a/src/quality/SMath__Tests/Functions1/IdentityTests.cs
+++ b/src/quality/SMath__Tests/Functions1/IdentityTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace SMath.Functions1;
+
+public class IdentityTests
+{
+    [Fact]
+    public void NumberDomain_IsFullRange()
+    {
+        // Regression: NumberDomain used to return (MaxValue, MaxValue).
+        // The identity function is defined for every number, so the domain
+        // must span the whole numeric range.
+        var domain = Identity.NumberDomain<double>();
+        Assert.Equal(double.MinValue, domain.Min);
+        Assert.Equal(double.MaxValue, domain.Max);
+    }
+
+    [Fact]
+    public void Domain_IsFullRange()
+    {
+        var domain = Identity.Domain<double>();
+        Assert.Equal(double.NegativeInfinity, domain.Min);
+        Assert.Equal(double.PositiveInfinity, domain.Max);
+    }
+
+    [Fact]
+    public void NumberImage_IsFullRange()
+    {
+        var image = Identity.NumberImage<double>();
+        Assert.Equal(double.MinValue, image.Min);
+        Assert.Equal(double.MaxValue, image.Max);
+    }
+
+    [Theory]
+    [InlineData(-3d)]
+    [InlineData(0d)]
+    [InlineData(2.5d)]
+    public void Eval_ReturnsInput(double x)
+    {
+        Assert.Equal(x, Identity.Eval(x));
+    }
+
+    [Fact]
+    public void IsOdd()
+    {
+        Assert.True(Identity.IsOdd);
+        Assert.False(Identity.IsEven);
+    }
+}

--- a/src/quality/SMath__Tests/Geometry3D/Point3Tests.cs
+++ b/src/quality/SMath__Tests/Geometry3D/Point3Tests.cs
@@ -1,7 +1,7 @@
-﻿using SMath.Geometry2D;
+﻿using SMath.Geometry3D;
 using Xunit;
 
-namespace SMath.Geometry2D;
+namespace SMath.Geometry3D;
 
 public class Point3Tests
 {

--- a/src/quality/SMath__Tests/Geometry3D/SphereTests.cs
+++ b/src/quality/SMath__Tests/Geometry3D/SphereTests.cs
@@ -1,7 +1,7 @@
 ﻿using SMath.Geometry3D;
 using Xunit;
 
-namespace SMath.Geometry2D;
+namespace SMath.Geometry3D;
 
 public class SphereTests
 {

--- a/src/quality/SMath__Tests/Statistics/PearsonCorrelationTest.cs
+++ b/src/quality/SMath__Tests/Statistics/PearsonCorrelationTest.cs
@@ -104,5 +104,33 @@ public class PearsonCorrelationTest
     [Fact]
     public void EvalArrayPerf_BothSequencesAreEmpty_NoException() =>
         PearsonCorrelation.EvalPerf(Array.Empty<double>(), Array.Empty<double>(), 0);
+
+    [Fact]
+    public void EvalArrayPerf_ZeroLag_EqualsPlainEval()
+    {
+        var a = new[] { 1d, 2d, 4d, 7d, 11d, 16d };
+        var b = new[] { 2d, 3d, 5d, 8d, 13d, 21d };
+
+        // With lag 0 the perf variant must match the plain Pearson correlation.
+        Assert.Equal(PearsonCorrelation.Eval(a, b), PearsonCorrelation.EvalPerf(a, b, 0), 6);
+    }
+
+    [Fact]
+    public void EvalArrayPerf_NegativeLag_UsesEdgeClamping()
+    {
+        // Regression: for negative lags the edge-clamping index guard used the
+        // nonsensical condition 'iy < Count - iy', which wrongly clamped every
+        // index in the upper half of the sequence to the last element.
+        // A negative lag of -1 shifts b right by one with the first element
+        // repeated on the leading edge, so the reference is b clamped as below.
+        var a = new[] { 1d, 2d, 4d, 7d, 11d, 16d };
+        var b = new[] { 2d, 3d, 5d, 8d, 13d, 21d };
+
+        // clamped[i] = b[max(0, i - 1)]
+        var clamped = new[] { b[0], b[0], b[1], b[2], b[3], b[4] };
+        var expected = PearsonCorrelation.Eval(a, clamped);
+
+        Assert.Equal(expected, PearsonCorrelation.EvalPerf(a, b, -1), 6);
+    }
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR fixes several bugs across the codebase:
1. Corrects namespace declarations in Geometry3D files (Point3 and Sphere)
2. Fixes a regression in the Identity function's NumberDomain calculation
3. Fixes an edge-clamping logic error in PearsonCorrelation's EvalPerf method
4. Adds comprehensive test coverage for the fixed functionality

## Key Changes

- **Geometry3D Namespace Fix**: Corrected incorrect `SMath.Geometry2D` namespace declarations to `SMath.Geometry3D` in:
  - `Point3.cs`
  - `Point3Tests.cs`
  - `SphereTests.cs`

- **Identity.NumberDomain Regression Fix**: Changed `NumberDomain<N>()` return value from `(N.MaxValue, N.MaxValue)` to `(N.MinValue, N.MaxValue)` to correctly represent the full numeric range for the identity function

- **PearsonCorrelation.EvalPerf Logic Fix**: Corrected the edge-clamping index guard condition from `iy < numbers2.Count - iy` to `iy < numbers2.Count`. The original condition incorrectly clamped indices in the upper half of sequences to the last element when using negative lags

- **Test Coverage**: Added comprehensive test suite for Identity function and regression tests for PearsonCorrelation.EvalPerf with zero lag and negative lag scenarios

## Notable Details

The PearsonCorrelation fix addresses a regression where negative lag calculations would produce incorrect results due to a nonsensical comparison operator that didn't properly guard array bounds. The new tests verify both the zero-lag equivalence and the correct edge-clamping behavior for negative lags.

https://claude.ai/code/session_017bdUVCFhj9rXGw7mSpGW15