### PR TITLE
Update publish workflow to use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -43,5 +44,11 @@ jobs:
       - name: Publish to Github Package Registry
         run: dotnet nuget push "${{ env.package-dir }}"/**/*.nupkg
 
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ github.repository_owner }}
+
       - name: Publish to Nuget.org
-        run: dotnet nuget push "${{ env.package-dir }}"/**/*.nupkg --api-key ${{ secrets.NUGET_AUTH_TOKEN }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "${{ env.package-dir }}"/**/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/src/quality/SMath__Tests/SMath__Tests.csproj
+++ b/src/quality/SMath__Tests/SMath__Tests.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>SMath</RootNamespace>
+		<UseAppHost>true</UseAppHost>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updates `.github/workflows/publish.yml` to authenticate via OIDC instead of a long-lived secret API key. Also fixed `SMath__Tests.csproj` TFM.

---
*PR created automatically by Jules for task [12860734554389449648](https://jules.google.com/task/12860734554389449648) started by @jirikostiha*