### PR TITLE
ci: remove GitHub Packages publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
       id-token: write
 
@@ -31,18 +30,12 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
-          source-url: https://nuget.pkg.github.com/jirikostiha/index.json
-        env:
-           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         run: dotnet publish "${{ env.sln-path }}" -c Release
 
       - name: Pack
         run: dotnet pack "${{ env.sln-path }}" -c Release -o "${{ env.package-dir }}" --no-build
-
-      - name: Publish to Github Package Registry
-        run: dotnet nuget push "${{ env.package-dir }}"/**/*.nupkg
 
       - name: NuGet login (OIDC)
         uses: NuGet/login@v1


### PR DESCRIPTION
Removed the publish to GitHub packages step from the `publish.yml` workflow, as well as the unused associated variables (`source-url`, `NUGET_AUTH_TOKEN`, and `packages: write` permission).

---
*PR created automatically by Jules for task [6563606409481809159](https://jules.google.com/task/6563606409481809159) started by @jirikostiha*